### PR TITLE
[#IP-198] [#IP-198] add dgc selector to getCertificate endpoint

### DIFF
--- a/GetCertificate/index.ts
+++ b/GetCertificate/index.ts
@@ -15,7 +15,7 @@ const config = getConfigOrThrow();
 const dgcClientSelector = createDGCClientSelector(config, process.env);
 
 // Add express route
-app.get("/api/v1/certificate", getGetCertificateHandler(dgcClientSelector));
+app.post("/api/v1/certificate", getGetCertificateHandler(dgcClientSelector));
 
 const azureFunctionHandler = createAzureFunctionHandler(app);
 

--- a/GetCertificate/index.ts
+++ b/GetCertificate/index.ts
@@ -3,20 +3,19 @@ import * as express from "express";
 import { secureExpressApp } from "@pagopa/io-functions-commons/dist/src/utils/express";
 import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import createAzureFunctionHandler from "@pagopa/express-azure-functions/dist/src/createAzureFunctionsHandler";
-import { clients } from "../utils/dgc";
+import { createDGCClientSelector } from "../utils/dgcClientSelector";
+import { getConfigOrThrow } from "../utils/config";
 import { getGetCertificateHandler } from "./handler";
 
 // Setup Express
 const app = express();
 secureExpressApp(app);
 
+const config = getConfigOrThrow();
+const dgcClientSelector = createDGCClientSelector(config, process.env);
+
 // Add express route
-app.get(
-  "/api/v1/certificate",
-  getGetCertificateHandler(
-    /* TODO: switch client based on provided fiscal code */ clients.PROD
-  )
-);
+app.get("/api/v1/certificate", getGetCertificateHandler(dgcClientSelector));
 
 const azureFunctionHandler = createAzureFunctionHandler(app);
 

--- a/env.example
+++ b/env.example
@@ -9,16 +9,16 @@ FNSERVICES_API_URL=http://localhost:7073
 # ----––------------------
 DGC_LOAD_TEST_CLIENT_CERT=<Cert>
 DGC_LOAD_TEST_CLIENT_KEY=<Key>
-DGC_LOAD_TEST_CLIENT_URL=<Url>
+DGC_LOAD_TEST_URL=<Url>
 DGC_PROD_CLIENT_CERT=<Cert>
 DGC_PROD_CLIENT_KEY=<Key>
-DGC_PROD_CLIENT_URL=<Url>
+DGC_PROD_URL=<Url>
 DGC_UAT_CLIENT_CERT=<Cert>
 DGC_UAT_CLIENT_KEY=<Key>
-DGC_UAT_CLIENT_URL=<Url>
+DGC_UAT_URL=<Url>
 
 # -------------------
 # Feature flags
 # -------------------
-TEST_FISCAL_CODES_UAT=<Comma separated list of fiscal codes>
-TEST_FISCAL_CODES_LOAD=<Comma separated list of fiscal codes>
+DGC_UAT_FISCAL_CODES=<Comma separated list of fiscal codes>
+LOAD_TEST_FISCAL_CODES=<Comma separated list of fiscal codes>

--- a/utils/__tests__/dgcClientSelector.test.ts
+++ b/utils/__tests__/dgcClientSelector.test.ts
@@ -26,8 +26,8 @@ const aUATKey = "uat_key";
 const aConfig = ({
   DGC_UAT_CLIENT_CERT: aUATCert,
   DGC_UAT_CLIENT_KEY: aUATKey,
-  DGC_LOAD_CLIENT_CERT: aTestCert,
-  DGC_LOAD_CLIENT_KEY: aTestKey,
+  DGC_LOAD_TEST_CLIENT_CERT: aTestCert,
+  DGC_LOAD_TEST_CLIENT_KEY: aTestKey,
   DGC_PROD_CLIENT_CERT: aProdCert,
   DGC_PROD_CLIENT_KEY: aProdKey,
   LOAD_TEST_FISCAL_CODES: [aLoadTestFiscalCode],

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -26,8 +26,8 @@ const DCGConfigUAT = t.interface({
 });
 
 const DCGConfigLOAD = t.interface({
-  DGC_LOAD_CLIENT_CERT: NonEmptyString,
-  DGC_LOAD_CLIENT_KEY: NonEmptyString,
+  DGC_LOAD_TEST_CLIENT_CERT: NonEmptyString,
+  DGC_LOAD_TEST_CLIENT_KEY: NonEmptyString,
   DGC_LOAD_TEST_URL: HttpsUrlFromString,
   LOAD_TEST_FISCAL_CODES: CommaSeparatedListOf(FiscalCode)
 });

--- a/utils/dgc.ts
+++ b/utils/dgc.ts
@@ -13,8 +13,8 @@ export const clients = {
     baseUrl: config.DGC_LOAD_TEST_URL.href,
     fetchApi: getFetchWithClientCertificate(
       process.env,
-      config.DGC_LOAD_CLIENT_CERT,
-      config.DGC_LOAD_CLIENT_KEY
+      config.DGC_LOAD_TEST_CLIENT_CERT,
+      config.DGC_LOAD_TEST_CLIENT_KEY
     )
   }),
   PROD: createDGCClient({

--- a/utils/dgcClientSelector.ts
+++ b/utils/dgcClientSelector.ts
@@ -24,8 +24,8 @@ export const createDGCClientSelector = (
     DGC_UAT_CLIENT_KEY,
     DGC_UAT_FISCAL_CODES,
     DGC_UAT_URL,
-    DGC_LOAD_CLIENT_CERT,
-    DGC_LOAD_CLIENT_KEY,
+    DGC_LOAD_TEST_CLIENT_CERT,
+    DGC_LOAD_TEST_CLIENT_KEY,
     LOAD_TEST_FISCAL_CODES,
     DGC_LOAD_TEST_URL,
     DGC_PROD_CLIENT_CERT,
@@ -58,8 +58,8 @@ export const createDGCClientSelector = (
     baseUrl: DGC_LOAD_TEST_URL.href,
     fetchApi: getFetchWithClientCertificate(
       env,
-      DGC_LOAD_CLIENT_CERT,
-      DGC_LOAD_CLIENT_KEY
+      DGC_LOAD_TEST_CLIENT_CERT,
+      DGC_LOAD_TEST_CLIENT_KEY
     )
   });
 


### PR DESCRIPTION
add dgc selector at getCertificate endpoint implementation in order to call different target endpoint for different fiscal_code (test,UAT,Prod).

#### List of Changes
changed the getCertificate implementation to use the dcg selector

#### Motivation and Context

#### How Has This Been Tested?
Not tested yet

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
