### PR TITLE
[#IPV-95] Forward 403 responses in getLimitedProfileByPost

### DIFF
--- a/utils/__tests__/serviceClient.test.ts
+++ b/utils/__tests__/serviceClient.test.ts
@@ -1,7 +1,6 @@
 import { readableReport } from "@pagopa/ts-commons/lib/reporters";
 import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
 import { HttpsUrlFromString } from "@pagopa/ts-commons/lib/url";
-import { unknown } from "io-ts";
 import { context } from "../../__mocks__/durable-functions";
 import { createClient, createPoolSelector } from "../serviceClient";
 

--- a/utils/__tests__/serviceClient.test.ts
+++ b/utils/__tests__/serviceClient.test.ts
@@ -1,7 +1,9 @@
 import { readableReport } from "@pagopa/ts-commons/lib/reporters";
 import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
 import { HttpsUrlFromString } from "@pagopa/ts-commons/lib/url";
-import { createPoolSelector } from "../serviceClient";
+import { unknown } from "io-ts";
+import { context } from "../../__mocks__/durable-functions";
+import { createClient, createPoolSelector } from "../serviceClient";
 
 const aFiscalCodeSet = [
   "PRVPRV25A01H501B", // c58c7c882b44499b1c55a5772eb89aff92e9777583dc28544c9cbaf3aba434f9
@@ -24,6 +26,15 @@ const elem2 = HttpsUrlFromString.decode("https://elem2.com").getOrElseL(_ =>
 const elem3 = HttpsUrlFromString.decode("https://elem3.com").getOrElseL(_ =>
   fail(`Failed to decode elem3: ${readableReport(_)}`)
 );
+
+const mockFetch = <T>(status: number, json: T): typeof fetch => {
+  return (jest.fn((_1, _2) =>
+    Promise.resolve({
+      json: () => Promise.resolve(json),
+      status
+    })
+  ) as unknown) as typeof fetch;
+};
 
 describe("createPoolSelector", () => {
   it("should select the element in a pool of one", () => {
@@ -70,5 +81,41 @@ describe("createPoolSelector", () => {
       elem2.href,
       elem3.href
     ]);
+  });
+});
+
+describe("createClient#getLimitedProfileByPost", () => {
+  it("should return 403 if the service is not authorized to get the profile", async () => {
+    const fetchApi = mockFetch(403, {});
+    const client = createClient(
+      fetchApi,
+      [{ href: "https://localhost" } as any],
+      "secret"
+    );
+    const response = await client
+      .getLimitedProfileByPost({} as any, aFiscalCodeSet[0], context)
+      .run();
+    expect(response.isLeft()).toBeTruthy();
+    expect(response.value).toHaveProperty(
+      "kind",
+      "IResponseErrorForbiddenNotAuthorizedForRecipient"
+    );
+  });
+
+  it("should return 403 if the profile was not found", async () => {
+    const fetchApi = mockFetch(404, {});
+    const client = createClient(
+      fetchApi,
+      [{ href: "https://localhost" } as any],
+      "secret"
+    );
+    const response = await client
+      .getLimitedProfileByPost({} as any, aFiscalCodeSet[0], context)
+      .run();
+    expect(response.isLeft()).toBeTruthy();
+    expect(response.value).toHaveProperty(
+      "kind",
+      "IResponseErrorForbiddenNotAuthorizedForRecipient"
+    );
   });
 });

--- a/utils/serviceClient.ts
+++ b/utils/serviceClient.ts
@@ -133,9 +133,9 @@ export const createClient = (
               () => responseRaw.json(),
               error => ResponseErrorInternal(String(error))
             )
-            // If the profile was not found returns status code 403
+            // If the profile was not found or service is not authorized returns status code 403
             .filterOrElseL(
-              _ => responseRaw.status !== 404,
+              _ => responseRaw.status !== 404 && responseRaw.status !== 403,
               _ => ResponseErrorForbiddenNotAuthorizedForRecipient
             )
             // If the response is not 200 returns status code 500


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
`SubmitMessageForUser` returns 403 when `GetLimitedProfileByPost` returns unauthorized responses.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To performs a load test for DGC the unauthorized responses from `GetLimitedProfileByPost` should be forwarded to DGC service.
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
