### PR TITLE
German translated Eu Covid Cert templates

### DIFF
--- a/GetCertificate/__tests__/__snapshots__/parser.test.ts.snap
+++ b/GetCertificate/__tests__/__snapshots__/parser.test.ts.snap
@@ -54,12 +54,14 @@ Right {
         "tg": "COVID-19",
         "tr": Object {
           "displays": Object {
+            "de_DE": "",
             "en_GB": "Not detected",
             "it_IT": "Negativo",
           },
         },
         "tt": Object {
           "displays": Object {
+            "de_DE": "",
             "en_GB": "Nucleic acid amplification with probe detection",
             "it_IT": "Test molecolare",
           },
@@ -155,12 +157,14 @@ Right {
         "tg": "COVID-19",
         "tr": Object {
           "displays": Object {
+            "de_DE": "",
             "en_GB": "Not detected",
             "it_IT": "Negativo",
           },
         },
         "tt": Object {
           "displays": Object {
+            "de_DE": "",
             "en_GB": "Nucleic acid amplification with probe detection",
             "it_IT": "Test molecolare",
           },

--- a/GetCertificate/__tests__/__snapshots__/printer_recovery_detail_de.test.ts.snap
+++ b/GetCertificate/__tests__/__snapshots__/printer_recovery_detail_de.test.ts.snap
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Printer - Recovery - Detail - de_DE should print its markdown 1`] = `
+"
+## Heilungsurkunde
+
+Zielkrankheit oder Erreger, von dem die Person geheilt wird  
+**COVID-19**  
+
+Datum des ersten positiven Molekulartests  
+**2021-04-10**  
+
+Zustand, in dem der erste positive Molekulartest durchgeführt wurde  
+**IT**  
+
+Subjekt, das die Zertifizierung ausgestellt hat  
+**Gesundheitsministerium**  
+ 
+Zertifizierung gültig ab  
+**2021-04-20**  
+
+Zertifizierung gültig bis  
+**2021-09-10**  
+
+***
+
+*Diese Bescheinigung ist kein Reisedokument.  
+Die wissenschaftlichen Erkenntnisse zu COVID-19-Impfung, -Tests und -Wiederherstellung entwickeln sich weiter, auch unter Berücksichtigung der neuen Varianten des Virus.*  
+*Bitte informieren Sie sich vor der Reise über die am Zielort geltenden Gesundheitsmaßnahmen und die damit verbundenen Einschränkungen auch auf der Website:*   
+[https://reopen.europa.eu/it](https://reopen.europa.eu/it)
+  
+***
+  
+Weitere Informationen und den Download des Zertifikats im druckfähigen PDF-Format finden Sie der Website  
+[www.dgc.gov.it](https://www.dgc.gov.it)
+<br/><br/><br/><br/><br/>
+"
+`;
+
+exports[`Printer - Recovery - Detail - de_DE should print its markdown with placeholder, if some value is not in valueset 1`] = `
+"
+## Heilungsurkunde
+
+Zielkrankheit oder Erreger, von dem die Person geheilt wird  
+**---**  
+
+Datum des ersten positiven Molekulartests  
+**2021-04-10**  
+
+Zustand, in dem der erste positive Molekulartest durchgeführt wurde  
+**IT**  
+
+Subjekt, das die Zertifizierung ausgestellt hat  
+**Gesundheitsministerium**  
+ 
+Zertifizierung gültig ab  
+**2021-04-20**  
+
+Zertifizierung gültig bis  
+**2021-09-10**  
+
+***
+
+*Diese Bescheinigung ist kein Reisedokument.  
+Die wissenschaftlichen Erkenntnisse zu COVID-19-Impfung, -Tests und -Wiederherstellung entwickeln sich weiter, auch unter Berücksichtigung der neuen Varianten des Virus.*  
+*Bitte informieren Sie sich vor der Reise über die am Zielort geltenden Gesundheitsmaßnahmen und die damit verbundenen Einschränkungen auch auf der Website:*   
+[https://reopen.europa.eu/it](https://reopen.europa.eu/it)
+  
+***
+  
+Weitere Informationen und den Download des Zertifikats im druckfähigen PDF-Format finden Sie der Website  
+[www.dgc.gov.it](https://www.dgc.gov.it)
+<br/><br/><br/><br/><br/>
+"
+`;

--- a/GetCertificate/__tests__/__snapshots__/printer_recovery_detail_en.test.ts.snap
+++ b/GetCertificate/__tests__/__snapshots__/printer_recovery_detail_en.test.ts.snap
@@ -10,7 +10,7 @@ Disease or agent the citizen has recovered from
 Date of first positive NAAT test result  
 **2021-04-10**  
 
-Member State of test  
+State of test  
 **IT**  
 
 Certificate issuer  
@@ -47,7 +47,7 @@ Disease or agent the citizen has recovered from
 Date of first positive NAAT test result  
 **2021-04-10**  
 
-Member State of test  
+State of test  
 **IT**  
 
 Certificate issuer  

--- a/GetCertificate/__tests__/__snapshots__/printer_recovery_detail_it.test.ts.snap
+++ b/GetCertificate/__tests__/__snapshots__/printer_recovery_detail_it.test.ts.snap
@@ -10,10 +10,10 @@ Malattia o agente bersaglio da cui la persona è guarita
 Data del primo test molecolare positivo  
 **10-04-2021**  
 
-Stato Membro in cui è stato eseguito il primo test molecolare positivo  
+Stato in cui è stato eseguito il primo test molecolare positivo  
 **IT**  
 
-Struttura che ha rilasciato la certificazione  
+Soggetto che ha rilasciato la certificazione  
 **Ministero della Salute**  
  
 Certificazione valida dal  

--- a/GetCertificate/__tests__/__snapshots__/printer_recovery_info_de.test.ts.snap
+++ b/GetCertificate/__tests__/__snapshots__/printer_recovery_info_de.test.ts.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Printer - Recovery - Info - de_DE should print its markdown 1`] = `
+"
+Surname(s) and forename(s)  
+*Cognome e Nome*  
+**Di Caprio Marilù Teresa**  
+
+Date of birth  
+*Data di nascita (aaaa-mm-gg)*  
+**1977-06-16**  
+
+Unique Certificate Identifier  
+*Identificativo univoco del certificato*  
+**01ITE7300E1AB2A84C719004F103DCB1F70A#6**  
+
+[copia l’identificativo](iohandledlink://copy:01ITE7300E1AB2A84C719004F103DCB1F70A#6)
+<br/><br/><br/><br/><br/>
+"
+`;

--- a/GetCertificate/__tests__/__snapshots__/printer_test_detail_de.test.ts.snap
+++ b/GetCertificate/__tests__/__snapshots__/printer_test_detail_de.test.ts.snap
@@ -1,0 +1,56 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Printer - Test - Detail - de_DE should print its markdown 1`] = `
+"
+## Test Zertifikat  
+***
+**Bescheinigung gültig für 48 Stunden ab dem Zeitpunkt der Abholung**
+***
+
+Zielkrankheit oder -wirkstoff  
+**COVID-19**  
+
+Testtyp  
+**Molekularer Test**  
+
+Testergebnis  
+**Negativer**  
+
+Molekularer Testname  
+**Roche LightCycler qPCR**  
+
+Name des Antigentests und Name des Herstellers  
+**Abbott Rapid Diagnostics, Panbio COVID-19 Ag Rapid Test**  
+
+Datum und Uhrzeit der Probenentnahme  
+**2021-05-10 12:27**  
+
+Datum und Uhrzeit des Testergebnis  
+**2021-05-11 14:27**  
+
+Zentrum oder Einrichtung, in der der Test durchgeführt wurde  
+**Policlinico Umberto I**  
+
+Staat, in dem der Test durchgeführt wurde  
+**IT**  
+
+Subjekt, das die Zertifizierung ausgestellt hat  
+**Gesundheitsministerium**  
+
+Eindeutige Kennung des Zertifikats  
+**01IT0BFC9866D3854EAC82C21654B6F6DE32#1**  
+  
+***
+
+*Diese Bescheinigung ist kein Reisedokument.  
+Die wissenschaftlichen Erkenntnisse zu COVID-19-Impfung, -Tests und -Wiederherstellung entwickeln sich weiter, auch unter Berücksichtigung der neuen Varianten des Virus.*  
+*Bitte informieren Sie sich vor der Reise über die am Zielort geltenden Gesundheitsmaßnahmen und die damit verbundenen Einschränkungen auch auf der Website:*   
+[https://reopen.europa.eu/it](https://reopen.europa.eu/it)
+  
+***
+  
+Weitere Informationen und den Download des Zertifikats im druckfähigen PDF-Format finden Sie der Website  
+[www.dgc.gov.it](https://www.dgc.gov.it)
+<br/><br/><br/><br/><br/>
+"
+`;

--- a/GetCertificate/__tests__/__snapshots__/printer_test_detail_en.test.ts.snap
+++ b/GetCertificate/__tests__/__snapshots__/printer_test_detail_en.test.ts.snap
@@ -31,7 +31,7 @@ Date and time of the test result production
 Testing centre or facility  
 **Policlinico Umberto I**  
 
-Member State of test  
+State of test  
 **IT**  
 
 Certificate issuer  

--- a/GetCertificate/__tests__/__snapshots__/printer_test_detail_it.test.ts.snap
+++ b/GetCertificate/__tests__/__snapshots__/printer_test_detail_it.test.ts.snap
@@ -31,10 +31,10 @@ Data e ora del risultato del test
 Centro o struttura in cui è stato eseguito il test  
 **Policlinico Umberto I**  
 
-Stato Membro in cui è stato eseguito il test  
+Stato in cui è stato eseguito il test  
 **IT**  
 
-Struttura che ha rilasciato la certificazione  
+Soggetto che ha rilasciato la certificazione  
 **Ministero della Salute**  
 
 Identificativo univoco del certificato  

--- a/GetCertificate/__tests__/__snapshots__/printer_test_info_de.test.ts.snap
+++ b/GetCertificate/__tests__/__snapshots__/printer_test_info_de.test.ts.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Printer - Test - Info - de_DE should print its markdown 1`] = `
+"
+Surname(s) and forename(s)  
+*Cognome e Nome*  
+**Di Caprio Marilù Teresa**  
+
+Date of birth  
+*Data di nascita (aaaa-mm-gg)*  
+**1977-06-16**  
+
+Unique Certificate Identifier  
+*Identificativo univoco del certificato*  
+**01IT0BFC9866D3854EAC82C21654B6F6DE32#1**  
+
+[copia l’identificativo](iohandledlink://copy:01IT0BFC9866D3854EAC82C21654B6F6DE32#1)
+<br/><br/><br/><br/><br/>
+"
+`;

--- a/GetCertificate/__tests__/__snapshots__/printer_vaccine_detail_de.test.ts.snap
+++ b/GetCertificate/__tests__/__snapshots__/printer_vaccine_detail_de.test.ts.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Printer - Test - Detail - de_DE should print its markdown 1`] = `
+"
+## Impfstoffdaten  
+***
+**Zertifizierung gültig für 270 Tage (9 Monate) ab dem Datum der letzten Verabreichung**
+***
+
+Zielkrankheit oder -wirkstoff  
+**COVID-19**  
+
+Art des verabreichten Impfstoffs  
+**SARS-CoV-2 mRNA vaccine**  
+
+Impfstoffname  
+**Comirnaty**  
+
+Impfstoffhersteller oder MAH  
+**Biontech Manufacturing GmbH**  
+
+Anzahl der abgegebenen Dosis / Gesamtzahl der geplanten Dosen  
+**2 / 2**  
+
+Datum der letzten Verabreichung  
+**2021-04-10**  
+
+Staat, in dem die Impfung durchgeführt wurde  
+**IT**  
+
+Subjekt, das die Zertifizierung ausgestellt hat  
+**Gesundheitsministerium**  
+
+Eindeutige Kennung des Zertifikats  
+**01ITE7300E1AB2A84C719004F103DCB1F70A#6**  
+  
+***
+  
+*Diese Bescheinigung ist kein Reisedokument.  
+Die wissenschaftlichen Erkenntnisse zu COVID-19-Impfung, -Tests und -Wiederherstellung entwickeln sich weiter, auch unter Berücksichtigung der neuen Varianten des Virus.*  
+*Bitte informieren Sie sich vor der Reise über die am Zielort geltenden Gesundheitsmaßnahmen und die damit verbundenen Einschränkungen auch auf der Website:*   
+[https://reopen.europa.eu/it](https://reopen.europa.eu/it)
+  
+***
+  
+Weitere Informationen und den Download des Zertifikats im druckfähigen PDF-Format finden Sie der Website  
+[www.dgc.gov.it](https://www.dgc.gov.it)
+<br/><br/><br/><br/><br/>
+"
+`;

--- a/GetCertificate/__tests__/__snapshots__/printer_vaccine_detail_en.test.ts.snap
+++ b/GetCertificate/__tests__/__snapshots__/printer_vaccine_detail_en.test.ts.snap
@@ -25,7 +25,7 @@ Number in a series of vaccinations doses / overall number of vaccination in the 
 Date of vaccination  
 **2021-04-10**  
 
-Member State of vaccination  
+State of vaccination  
 **IT**
 
 Certificate issuer  

--- a/GetCertificate/__tests__/__snapshots__/printer_vaccine_detail_it.test.ts.snap
+++ b/GetCertificate/__tests__/__snapshots__/printer_vaccine_detail_it.test.ts.snap
@@ -25,10 +25,10 @@ Numero della dose effettuata / numero totale dosi previste
 Data dell’ultima somministrazione  
 **10-04-2021**  
 
-Stato Membro in cui è stata eseguita la vaccinazione  
+Stato in cui è stata eseguita la vaccinazione  
 **IT**  
 
-Struttura che ha rilasciato la certificazione  
+Soggetto che ha rilasciato la certificazione  
 **Ministero della Salute**  
 
 Identificativo univoco del certificato  

--- a/GetCertificate/__tests__/__snapshots__/printer_vaccine_info_de.test.ts.snap
+++ b/GetCertificate/__tests__/__snapshots__/printer_vaccine_info_de.test.ts.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Printer - Vaccine - Info - de_DE should print its markdown 1`] = `
+"
+Surname(s) and forename(s)  
+*Cognome e Nome*  
+**Di Caprio Marilù Teresa**  
+
+Date of birth  
+*Data di nascita (aaaa-mm-gg)*  
+**1977-06-16**  
+
+Unique Certificate Identifier  
+*Identificativo univoco del certificato*  
+**01ITE7300E1AB2A84C719004F103DCB1F70A#6**  
+
+[copia l’identificativo](iohandledlink://copy:01ITE7300E1AB2A84C719004F103DCB1F70A#6)
+<br/><br/><br/><br/><br/>
+"
+`;

--- a/GetCertificate/__tests__/printer.test.ts
+++ b/GetCertificate/__tests__/printer.test.ts
@@ -4,7 +4,8 @@ import {
   formatCertificateIssuer,
   ITALY_HEALTHCARE_ISSUER,
   HEALTHCARE_DEP_IT,
-  HEALTHCARE_DEP_EN
+  HEALTHCARE_DEP_EN,
+  HEALTHCARE_DEP_DE
 } from "../printer";
 
 describe("Printer", () => {
@@ -16,13 +17,22 @@ describe("Printer", () => {
     expect(result).toEqual(HEALTHCARE_DEP_IT);
   });
 
-  it("should format Certificate Issuer with Ministry of Health if value is IT and language not it_IT", () => {
+  it("should format Certificate Issuer with Ministry of Health if value is IT and language is en_EN", () => {
     const result = formatCertificateIssuer(
       ITALY_HEALTHCARE_ISSUER,
-      PreferredLanguageEnum.fr_FR
+      PreferredLanguageEnum.en_GB
     );
     expect(result).toEqual(HEALTHCARE_DEP_EN);
   });
+
+  it("should format Certificate Issuer with Ministry of Health if value is IT and language is de_DE", () => {
+    const result = formatCertificateIssuer(
+      ITALY_HEALTHCARE_ISSUER,
+      PreferredLanguageEnum.de_DE
+    );
+    expect(result).toEqual(HEALTHCARE_DEP_DE);
+  });
+
   it("should format Certificate Issuer with its value if value is different from IT and language it_IT", () => {
     const result = formatCertificateIssuer(
       "a value",

--- a/GetCertificate/__tests__/printer.test.ts
+++ b/GetCertificate/__tests__/printer.test.ts
@@ -1,11 +1,14 @@
 import { PreferredLanguageEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/PreferredLanguage";
+import { some } from "fp-ts/lib/Option";
 
 import {
   formatCertificateIssuer,
   ITALY_HEALTHCARE_ISSUER,
   HEALTHCARE_DEP_IT,
   HEALTHCARE_DEP_EN,
-  HEALTHCARE_DEP_DE
+  HEALTHCARE_DEP_DE,
+  getPrinterForLanguage,
+  defaultPrinter
 } from "../printer";
 
 describe("Printer", () => {
@@ -39,5 +42,10 @@ describe("Printer", () => {
       PreferredLanguageEnum.en_GB
     );
     expect(result).toEqual("a value");
+  });
+
+  it("should get defaultPrinter if prefererred language is not supported", () => {
+    const result = getPrinterForLanguage(some(PreferredLanguageEnum.fr_FR));
+    expect(result).toBe(defaultPrinter);
   });
 });

--- a/GetCertificate/__tests__/printer_recovery_detail_de.test.ts
+++ b/GetCertificate/__tests__/printer_recovery_detail_de.test.ts
@@ -1,0 +1,69 @@
+import {
+  PreferredLanguage,
+  PreferredLanguageEnum
+} from "@pagopa/io-functions-commons/dist/generated/definitions/PreferredLanguage";
+import { some } from "fp-ts/lib/Option";
+
+import { Certificates } from "../certificate";
+import { printDetails } from "../printer";
+
+const language = PreferredLanguageEnum.de_DE;
+describe(`Printer - Recovery - Detail - ${language}`, () => {
+  it("should print its markdown", () => {
+    const certificate = Certificates.decode({
+      ver: "1.0.0",
+      nam: {
+        fn: "Di Caprio",
+        fnt: "DI<CAPRIO",
+        gn: "Marilù Teresa",
+        gnt: "MARILU<TERESA"
+      },
+      dob: "1977-06-16",
+      r: [
+        {
+          tg: "840539006",
+          fr: "2021-04-10",
+          co: "IT",
+          is: "IT",
+          df: "2021-04-20",
+          du: "2021-09-10",
+          ci: "01ITE7300E1AB2A84C719004F103DCB1F70A#6"
+        }
+      ]
+    }).getOrElseL(_ => {
+      throw "Error decoding object";
+    });
+
+    const result = printDetails(some(language), certificate);
+    expect(result).toMatchSnapshot();
+  });
+
+  it("should print its markdown with placeholder, if some value is not in valueset", () => {
+    const certificate = Certificates.decode({
+      ver: "1.0.0",
+      nam: {
+        fn: "Di Caprio",
+        fnt: "DI<CAPRIO",
+        gn: "Marilù Teresa",
+        gnt: "MARILU<TERESA"
+      },
+      dob: "1977-06-16",
+      r: [
+        {
+          tg: "NOTPRESENT",
+          fr: "2021-04-10",
+          co: "IT",
+          is: "IT",
+          df: "2021-04-20",
+          du: "2021-09-10",
+          ci: "01ITE7300E1AB2A84C719004F103DCB1F70A#6"
+        }
+      ]
+    }).getOrElseL(_ => {
+      throw "Error decoding object";
+    });
+
+    const result = printDetails(some(language), certificate);
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/GetCertificate/__tests__/printer_recovery_info_de.test.ts
+++ b/GetCertificate/__tests__/printer_recovery_info_de.test.ts
@@ -1,0 +1,38 @@
+import { PreferredLanguageEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/PreferredLanguage";
+import { some } from "fp-ts/lib/Option";
+
+import { Certificates } from "../certificate";
+import { printInfo } from "../printer";
+
+const language = PreferredLanguageEnum.de_DE;
+
+describe(`Printer - Recovery - Info - ${language}`, () => {
+  it("should print its markdown", () => {
+    const certificate = Certificates.decode({
+      ver: "1.0.0",
+      nam: {
+        fn: "Di Caprio",
+        fnt: "DI<CAPRIO",
+        gn: "Marilù Teresa",
+        gnt: "MARILU<TERESA"
+      },
+      dob: "1977-06-16",
+      r: [
+        {
+          tg: "840539006",
+          fr: "2021-04-10",
+          co: "IT",
+          is: "IT",
+          df: "2021-04-20",
+          du: "2021-09-10",
+          ci: "01ITE7300E1AB2A84C719004F103DCB1F70A#6"
+        }
+      ]
+    }).getOrElseL(_ => {
+      throw "Error decoding object";
+    });
+
+    const result = printInfo(some(language), certificate);
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/GetCertificate/__tests__/printer_test_detail_de.test.ts
+++ b/GetCertificate/__tests__/printer_test_detail_de.test.ts
@@ -1,0 +1,42 @@
+import { PreferredLanguageEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/PreferredLanguage";
+import { some } from "fp-ts/lib/Option";
+
+import { Certificates } from "../certificate";
+import { printDetails } from "../printer";
+
+const language = PreferredLanguageEnum.de_DE;
+
+describe(`Printer - Test - Detail - ${language}`, () => {
+  it("should print its markdown", () => {
+    const certificate = Certificates.decode({
+      ver: "1.0.0",
+      nam: {
+        fn: "Di Caprio",
+        fnt: "DI<CAPRIO",
+        gn: "Marilù Teresa",
+        gnt: "MARILU<TERESA"
+      },
+      dob: "1977-06-16",
+      t: [
+        {
+          tg: "840539006",
+          tt: "LP6464-4",
+          nm: "Roche LightCycler qPCR",
+          ma: "1232",
+          sc: "2021-05-10T10:27:15Z",
+          dr: "2021-05-11T12:27:15Z",
+          tr: "260415000",
+          tc: "Policlinico Umberto I",
+          co: "IT",
+          is: "IT",
+          ci: "01IT0BFC9866D3854EAC82C21654B6F6DE32#1"
+        }
+      ]
+    }).getOrElseL(_ => {
+      throw "Error decoding object";
+    });
+
+    const result = printDetails(some(language), certificate);
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/GetCertificate/__tests__/printer_test_info_de.test.ts
+++ b/GetCertificate/__tests__/printer_test_info_de.test.ts
@@ -1,0 +1,42 @@
+import { PreferredLanguageEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/PreferredLanguage";
+import { some } from "fp-ts/lib/Option";
+
+import { Certificates } from "../certificate";
+import { printInfo } from "../printer";
+
+const language = PreferredLanguageEnum.de_DE;
+
+describe(`Printer - Test - Info - ${language}`, () => {
+  it("should print its markdown", () => {
+    const certificate = Certificates.decode({
+      ver: "1.0.0",
+      nam: {
+        fn: "Di Caprio",
+        fnt: "DI<CAPRIO",
+        gn: "Marilù Teresa",
+        gnt: "MARILU<TERESA"
+      },
+      dob: "1977-06-16",
+      t: [
+        {
+          tg: "840539006",
+          tt: "LP6464-4",
+          nm: "Roche LightCycler qPCR",
+          ma: "",
+          sc: "2021-05-10T10:27:15Z",
+          dr: "2021-05-11T12:27:15Z",
+          tr: "260415000",
+          tc: "Policlinico Umberto I",
+          co: "IT",
+          is: "IT",
+          ci: "01IT0BFC9866D3854EAC82C21654B6F6DE32#1"
+        }
+      ]
+    }).getOrElseL(_ => {
+      throw "Error decoding object";
+    });
+
+    const result = printInfo(some(language), certificate);
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/GetCertificate/__tests__/printer_vaccine_detail_de.test.ts
+++ b/GetCertificate/__tests__/printer_vaccine_detail_de.test.ts
@@ -1,0 +1,41 @@
+import { PreferredLanguageEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/PreferredLanguage";
+import { some } from "fp-ts/lib/Option";
+
+import { Certificates } from "../certificate";
+import { printDetails } from "../printer";
+
+const language = PreferredLanguageEnum.de_DE;
+
+describe(`Printer - Test - Detail - ${language}`, () => {
+  it("should print its markdown", () => {
+    const certificate = Certificates.decode({
+      ver: "1.0.0",
+      nam: {
+        fn: "Di Caprio",
+        fnt: "DI<CAPRIO",
+        gn: "Marilù Teresa",
+        gnt: "MARILU<TERESA"
+      },
+      dob: "1977-06-16",
+      v: [
+        {
+          tg: "840539006",
+          vp: "1119349007",
+          mp: "EU/1/20/1528",
+          ma: "ORG-100030215",
+          dn: 2,
+          sd: 2,
+          dt: "2021-04-10",
+          co: "IT",
+          is: "IT",
+          ci: "01ITE7300E1AB2A84C719004F103DCB1F70A#6"
+        }
+      ]
+    }).getOrElseL(_ => {
+      throw "Error decoding object";
+    });
+
+    const result = printDetails(some(language), certificate);
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/GetCertificate/__tests__/printer_vaccine_info_de.test.ts
+++ b/GetCertificate/__tests__/printer_vaccine_info_de.test.ts
@@ -1,0 +1,41 @@
+import { PreferredLanguageEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/PreferredLanguage";
+import { some } from "fp-ts/lib/Option";
+
+import { Certificates } from "../certificate";
+import { printInfo } from "../printer";
+
+const language = PreferredLanguageEnum.de_DE;
+
+describe(`Printer - Vaccine - Info - ${language}`, () => {
+  it("should print its markdown", () => {
+    const certificate = Certificates.decode({
+      ver: "1.0.0",
+      nam: {
+        fn: "Di Caprio",
+        fnt: "DI<CAPRIO",
+        gn: "Marilù Teresa",
+        gnt: "MARILU<TERESA"
+      },
+      dob: "1977-06-16",
+      v: [
+        {
+          tg: "840539006",
+          vp: "1119349007",
+          mp: "EU/1/20/1528",
+          ma: "ORG-100030215",
+          dn: 2,
+          sd: 2,
+          dt: "2021-04-10",
+          co: "IT",
+          is: "IT",
+          ci: "01ITE7300E1AB2A84C719004F103DCB1F70A#6"
+        }
+      ]
+    }).getOrElseL(_ => {
+      throw "Error decoding object";
+    });
+
+    const result = printInfo(some(language), certificate);
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/GetCertificate/markdown/eucovidcertDetailsRecoveryDe.ts
+++ b/GetCertificate/markdown/eucovidcertDetailsRecoveryDe.ts
@@ -5,7 +5,7 @@ import { formatCertificateIssuer, formatDate } from "../printer";
 const fileLanguage = PreferredLanguageEnum.de_DE;
 
 export const getDetailPrinter = (tr: RecoveryEntry): string =>
-    `
+  `
 ## Heilungsurkunde
 
 Zielkrankheit oder Erreger, von dem die Person geheilt wird  

--- a/GetCertificate/markdown/eucovidcertDetailsRecoveryDe.ts
+++ b/GetCertificate/markdown/eucovidcertDetailsRecoveryDe.ts
@@ -1,0 +1,41 @@
+import { PreferredLanguageEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/PreferredLanguage";
+import { RecoveryEntry } from "../certificate";
+import { formatCertificateIssuer, formatDate } from "../printer";
+
+const fileLanguage = PreferredLanguageEnum.de_DE;
+
+export const getDetailPrinter = (tr: RecoveryEntry): string =>
+    `
+## Heilungsurkunde
+
+Zielkrankheit oder Erreger, von dem die Person geheilt wird  
+**${tr.tg}**  
+
+Datum des ersten positiven Molekulartests  
+**${formatDate(tr.fr, fileLanguage)}**  
+
+Zustand, in dem der erste positive Molekulartest durchgeführt wurde  
+**${tr.co}**  
+
+Subjekt, das die Zertifizierung ausgestellt hat  
+**${formatCertificateIssuer(tr.is, fileLanguage)}**  
+ 
+Zertifizierung gültig ab  
+**${formatDate(tr.df, fileLanguage)}**  
+
+Zertifizierung gültig bis  
+**${formatDate(tr.du, fileLanguage)}**  
+
+***
+
+*Diese Bescheinigung ist kein Reisedokument.  
+Die wissenschaftlichen Erkenntnisse zu COVID-19-Impfung, -Tests und -Wiederherstellung entwickeln sich weiter, auch unter Berücksichtigung der neuen Varianten des Virus.*  
+*Bitte informieren Sie sich vor der Reise über die am Zielort geltenden Gesundheitsmaßnahmen und die damit verbundenen Einschränkungen auch auf der Website:*   
+[https://reopen.europa.eu/it](https://reopen.europa.eu/it)
+  
+***
+  
+Weitere Informationen und den Download des Zertifikats im druckfähigen PDF-Format finden Sie der Website  
+[www.dgc.gov.it](https://www.dgc.gov.it)
+<br/><br/><br/><br/><br/>
+`;

--- a/GetCertificate/markdown/eucovidcertDetailsRecoveryEn.ts
+++ b/GetCertificate/markdown/eucovidcertDetailsRecoveryEn.ts
@@ -14,7 +14,7 @@ Disease or agent the citizen has recovered from
 Date of first positive NAAT test result  
 **${formatDate(tr.fr, fileLanguage)}**  
 
-Member State of test  
+State of test  
 **${tr.co}**  
 
 Certificate issuer  

--- a/GetCertificate/markdown/eucovidcertDetailsRecoveryIt.ts
+++ b/GetCertificate/markdown/eucovidcertDetailsRecoveryIt.ts
@@ -14,10 +14,10 @@ Malattia o agente bersaglio da cui la persona è guarita
 Data del primo test molecolare positivo  
 **${formatDate(tr.fr, fileLanguage)}**  
 
-Stato Membro in cui è stato eseguito il primo test molecolare positivo  
+Stato in cui è stato eseguito il primo test molecolare positivo  
 **${tr.co}**  
 
-Struttura che ha rilasciato la certificazione  
+Soggetto che ha rilasciato la certificazione  
 **${formatCertificateIssuer(tr.is, fileLanguage)}**  
  
 Certificazione valida dal  

--- a/GetCertificate/markdown/eucovidcertDetailsTestDe.ts
+++ b/GetCertificate/markdown/eucovidcertDetailsTestDe.ts
@@ -1,0 +1,63 @@
+import { PreferredLanguageEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/PreferredLanguage";
+import { isSome } from "fp-ts/lib/Option";
+import { TestEntry } from "../certificate";
+import { formatCertificateIssuer, formatDateAndTime } from "../printer";
+
+const fileLanguage = PreferredLanguageEnum.de_DE;
+
+export const getDetailPrinter = (te: TestEntry): string =>
+    `
+## Test Zertifikat  
+***
+**Bescheinigung gültig für 48 Stunden ab dem Zeitpunkt der Abholung**
+***
+
+Zielkrankheit oder -wirkstoff  
+**${te.tg}**  
+
+Testtyp  
+**${te.tt.displays[fileLanguage]}**  
+
+Testergebnis  
+**${te.tr.displays[fileLanguage]}**  
+
+${te.nm ? `Molekularer Testname  ` : ""}
+${te.nm ? `**${te.nm}**  ` : ""}
+
+${te.ma && isSome(te.ma)
+        ? `Name des Antigentests und Name des Herstellers  `
+        : ""
+    }
+${te.ma && isSome(te.ma) ? `**${te.ma.value}**  ` : ""}
+
+Datum und Uhrzeit der Probenentnahme  
+**${formatDateAndTime(te.sc, fileLanguage)}**  
+
+${te.dr ? `Datum und Uhrzeit des Testergebnis  ` : ""}
+${te.dr ? `**${formatDateAndTime(te.dr, fileLanguage)}**  ` : ""}
+
+Zentrum oder Einrichtung, in der der Test durchgeführt wurde  
+**${te.tc}**  
+
+Staat, in dem der Test durchgeführt wurde  
+**${te.co}**  
+
+Subjekt, das die Zertifizierung ausgestellt hat  
+**${formatCertificateIssuer(te.is, fileLanguage)}**  
+
+Eindeutige Kennung des Zertifikats  
+**${te.ci}**  
+  
+***
+
+*Diese Bescheinigung ist kein Reisedokument.  
+Die wissenschaftlichen Erkenntnisse zu COVID-19-Impfung, -Tests und -Wiederherstellung entwickeln sich weiter, auch unter Berücksichtigung der neuen Varianten des Virus.*  
+*Bitte informieren Sie sich vor der Reise über die am Zielort geltenden Gesundheitsmaßnahmen und die damit verbundenen Einschränkungen auch auf der Website:*   
+[https://reopen.europa.eu/it](https://reopen.europa.eu/it)
+  
+***
+  
+Weitere Informationen und den Download des Zertifikats im druckfähigen PDF-Format finden Sie der Website  
+[www.dgc.gov.it](https://www.dgc.gov.it)
+<br/><br/><br/><br/><br/>
+`;

--- a/GetCertificate/markdown/eucovidcertDetailsTestDe.ts
+++ b/GetCertificate/markdown/eucovidcertDetailsTestDe.ts
@@ -6,7 +6,7 @@ import { formatCertificateIssuer, formatDateAndTime } from "../printer";
 const fileLanguage = PreferredLanguageEnum.de_DE;
 
 export const getDetailPrinter = (te: TestEntry): string =>
-    `
+  `
 ## Test Zertifikat  
 ***
 **Bescheinigung gültig für 48 Stunden ab dem Zeitpunkt der Abholung**
@@ -24,10 +24,11 @@ Testergebnis
 ${te.nm ? `Molekularer Testname  ` : ""}
 ${te.nm ? `**${te.nm}**  ` : ""}
 
-${te.ma && isSome(te.ma)
-        ? `Name des Antigentests und Name des Herstellers  `
-        : ""
-    }
+${
+  te.ma && isSome(te.ma)
+    ? `Name des Antigentests und Name des Herstellers  `
+    : ""
+}
 ${te.ma && isSome(te.ma) ? `**${te.ma.value}**  ` : ""}
 
 Datum und Uhrzeit der Probenentnahme  

--- a/GetCertificate/markdown/eucovidcertDetailsTestEn.ts
+++ b/GetCertificate/markdown/eucovidcertDetailsTestEn.ts
@@ -36,7 +36,7 @@ ${te.dr ? `**${formatDateAndTime(te.dr, fileLanguage)}**  ` : ""}
 Testing centre or facility  
 **${te.tc}**  
 
-Member State of test  
+State of test  
 **${te.co}**  
 
 Certificate issuer  

--- a/GetCertificate/markdown/eucovidcertDetailsTestIt.ts
+++ b/GetCertificate/markdown/eucovidcertDetailsTestIt.ts
@@ -24,11 +24,10 @@ Risultato del test
 ${te.nm ? `Nome del test molecolare  ` : ""}
 ${te.nm ? `**${te.nm}**  ` : ""}
 
-${
-  te.ma && isSome(te.ma)
+${te.ma && isSome(te.ma)
     ? `Nome del test antigenico e nome del produttore  `
     : ""
-}
+  }
 ${te.ma && isSome(te.ma) ? `**${te.ma.value}**  ` : ""}
 
 Data e ora del prelievo del campione  
@@ -40,10 +39,10 @@ ${te.dr ? `**${formatDateAndTime(te.dr, fileLanguage)}**  ` : ""}
 Centro o struttura in cui è stato eseguito il test  
 **${te.tc}**  
 
-Stato Membro in cui è stato eseguito il test  
+Stato in cui è stato eseguito il test  
 **${te.co}**  
 
-Struttura che ha rilasciato la certificazione  
+Soggetto che ha rilasciato la certificazione  
 **${formatCertificateIssuer(te.is, fileLanguage)}**  
 
 Identificativo univoco del certificato  

--- a/GetCertificate/markdown/eucovidcertDetailsTestIt.ts
+++ b/GetCertificate/markdown/eucovidcertDetailsTestIt.ts
@@ -24,10 +24,11 @@ Risultato del test
 ${te.nm ? `Nome del test molecolare  ` : ""}
 ${te.nm ? `**${te.nm}**  ` : ""}
 
-${te.ma && isSome(te.ma)
+${
+  te.ma && isSome(te.ma)
     ? `Nome del test antigenico e nome del produttore  `
     : ""
-  }
+}
 ${te.ma && isSome(te.ma) ? `**${te.ma.value}**  ` : ""}
 
 Data e ora del prelievo del campione  

--- a/GetCertificate/markdown/eucovidcertDetailsVaccinationDe.ts
+++ b/GetCertificate/markdown/eucovidcertDetailsVaccinationDe.ts
@@ -1,0 +1,60 @@
+import { PreferredLanguageEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/PreferredLanguage";
+import { VaccinationEntry } from "../certificate";
+import {
+    isVaccinationProcessEnded,
+    formatDate,
+    formatCertificateIssuer
+} from "../printer";
+
+const fileLanguage = PreferredLanguageEnum.de_DE;
+
+export const getDetailPrinter = (v: VaccinationEntry): string =>
+    `
+## Impfstoffdaten  
+***
+${isVaccinationProcessEnded(v)
+        ? "**Zertifizierung gültig für 270 Tage (9 Monate) ab dem Datum der letzten Verabreichung**"
+        : "**Zertifizierung gültig bis zur nächsten Dosis**"
+    }
+***
+
+Zielkrankheit oder -wirkstoff  
+**${v.tg}**  
+
+Art des verabreichten Impfstoffs  
+**${v.vp}**  
+
+Impfstoffname  
+**${v.mp}**  
+
+Impfstoffhersteller oder MAH  
+**${v.ma}**  
+
+Anzahl der abgegebenen Dosis / Gesamtzahl der geplanten Dosen  
+**${v.dn} / ${v.sd}**  
+
+Datum der letzten Verabreichung  
+**${formatDate(v.dt, fileLanguage)}**  
+
+Staat, in dem die Impfung durchgeführt wurde  
+**${v.co}**  
+
+Subjekt, das die Zertifizierung ausgestellt hat  
+**${formatCertificateIssuer(v.is, fileLanguage)}**  
+
+Eindeutige Kennung des Zertifikats  
+**${v.ci}**  
+  
+***
+  
+*Diese Bescheinigung ist kein Reisedokument.  
+Die wissenschaftlichen Erkenntnisse zu COVID-19-Impfung, -Tests und -Wiederherstellung entwickeln sich weiter, auch unter Berücksichtigung der neuen Varianten des Virus.*  
+*Bitte informieren Sie sich vor der Reise über die am Zielort geltenden Gesundheitsmaßnahmen und die damit verbundenen Einschränkungen auch auf der Website:*   
+[https://reopen.europa.eu/it](https://reopen.europa.eu/it)
+  
+***
+  
+Weitere Informationen und den Download des Zertifikats im druckfähigen PDF-Format finden Sie der Website  
+[www.dgc.gov.it](https://www.dgc.gov.it)
+<br/><br/><br/><br/><br/>
+`;

--- a/GetCertificate/markdown/eucovidcertDetailsVaccinationDe.ts
+++ b/GetCertificate/markdown/eucovidcertDetailsVaccinationDe.ts
@@ -1,21 +1,22 @@
 import { PreferredLanguageEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/PreferredLanguage";
 import { VaccinationEntry } from "../certificate";
 import {
-    isVaccinationProcessEnded,
-    formatDate,
-    formatCertificateIssuer
+  isVaccinationProcessEnded,
+  formatDate,
+  formatCertificateIssuer
 } from "../printer";
 
 const fileLanguage = PreferredLanguageEnum.de_DE;
 
 export const getDetailPrinter = (v: VaccinationEntry): string =>
-    `
+  `
 ## Impfstoffdaten  
 ***
-${isVaccinationProcessEnded(v)
-        ? "**Zertifizierung gültig für 270 Tage (9 Monate) ab dem Datum der letzten Verabreichung**"
-        : "**Zertifizierung gültig bis zur nächsten Dosis**"
-    }
+${
+  isVaccinationProcessEnded(v)
+    ? "**Zertifizierung gültig für 270 Tage (9 Monate) ab dem Datum der letzten Verabreichung**"
+    : "**Zertifizierung gültig bis zur nächsten Dosis**"
+}
 ***
 
 Zielkrankheit oder -wirkstoff  

--- a/GetCertificate/markdown/eucovidcertDetailsVaccinationEn.ts
+++ b/GetCertificate/markdown/eucovidcertDetailsVaccinationEn.ts
@@ -12,10 +12,11 @@ export const getDetailPrinter = (v: VaccinationEntry): string =>
   `
 ## Vaccination Certificate  
 ***
-${isVaccinationProcessEnded(v)
+${
+  isVaccinationProcessEnded(v)
     ? "**Certification valid for 270 days (9 months) from the date of the last administration**"
     : "**Certification valid until next dose**"
-  }
+}
 ***
 
 Disease or agent targeted  

--- a/GetCertificate/markdown/eucovidcertDetailsVaccinationEn.ts
+++ b/GetCertificate/markdown/eucovidcertDetailsVaccinationEn.ts
@@ -12,11 +12,10 @@ export const getDetailPrinter = (v: VaccinationEntry): string =>
   `
 ## Vaccination Certificate  
 ***
-${
-  isVaccinationProcessEnded(v)
+${isVaccinationProcessEnded(v)
     ? "**Certification valid for 270 days (9 months) from the date of the last administration**"
     : "**Certification valid until next dose**"
-}
+  }
 ***
 
 Disease or agent targeted  
@@ -37,7 +36,7 @@ Number in a series of vaccinations doses / overall number of vaccination in the 
 Date of vaccination  
 **${formatDate(v.dt, fileLanguage)}**  
 
-Member State of vaccination  
+State of vaccination  
 **${v.co}**
 
 Certificate issuer  

--- a/GetCertificate/markdown/eucovidcertDetailsVaccinationIt.ts
+++ b/GetCertificate/markdown/eucovidcertDetailsVaccinationIt.ts
@@ -12,11 +12,10 @@ export const getDetailPrinter = (v: VaccinationEntry): string =>
   `
 ## Dati Vaccino  
 ***
-${
-  isVaccinationProcessEnded(v)
+${isVaccinationProcessEnded(v)
     ? "**Certificazione valida 270 giorni (9 mesi) dalla data dell'ultima somministrazione**"
     : "**Certificazione valida fino alla prossima dose**"
-}
+  }
 ***
 
 Malattia o agente bersaglio  
@@ -37,10 +36,10 @@ Numero della dose effettuata / numero totale dosi previste
 Data dell’ultima somministrazione  
 **${formatDate(v.dt, fileLanguage)}**  
 
-Stato Membro in cui è stata eseguita la vaccinazione  
+Stato in cui è stata eseguita la vaccinazione  
 **${v.co}**  
 
-Struttura che ha rilasciato la certificazione  
+Soggetto che ha rilasciato la certificazione  
 **${formatCertificateIssuer(v.is, fileLanguage)}**  
 
 Identificativo univoco del certificato  

--- a/GetCertificate/markdown/eucovidcertDetailsVaccinationIt.ts
+++ b/GetCertificate/markdown/eucovidcertDetailsVaccinationIt.ts
@@ -12,10 +12,11 @@ export const getDetailPrinter = (v: VaccinationEntry): string =>
   `
 ## Dati Vaccino  
 ***
-${isVaccinationProcessEnded(v)
+${
+  isVaccinationProcessEnded(v)
     ? "**Certificazione valida 270 giorni (9 mesi) dalla data dell'ultima somministrazione**"
     : "**Certificazione valida fino alla prossima dose**"
-  }
+}
 ***
 
 Malattia o agente bersaglio  

--- a/GetCertificate/markdown/eucovidcertInfoVaccinationDe.ts
+++ b/GetCertificate/markdown/eucovidcertInfoVaccinationDe.ts
@@ -7,7 +7,7 @@ const fileLanguage = PreferredLanguageEnum.de_DE;
 const uvci = (c: Certificates): string => printUvci(some(fileLanguage), c);
 
 export const getInfoPrinter = (c: Certificates): string =>
-    `
+  `
 Surname(s) and forename(s)  
 *Vorname und Nachname*  
 **${c.nam.fn} ${c.nam.gn}**  

--- a/GetCertificate/markdown/eucovidcertInfoVaccinationDe.ts
+++ b/GetCertificate/markdown/eucovidcertInfoVaccinationDe.ts
@@ -1,0 +1,25 @@
+import { PreferredLanguageEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/PreferredLanguage";
+import { some } from "fp-ts/lib/Option";
+import { Certificates } from "../certificate";
+import { formatDate, printUvci } from "../printer";
+
+const fileLanguage = PreferredLanguageEnum.de_DE;
+const uvci = (c: Certificates): string => printUvci(some(fileLanguage), c);
+
+export const getInfoPrinter = (c: Certificates): string =>
+    `
+Surname(s) and forename(s)  
+*Vorname und Nachname*  
+**${c.nam.fn} ${c.nam.gn}**  
+
+Date of birth  
+*Geburtsdatum (JJJJ-MM-TT)*  
+**${formatDate(c.dob, fileLanguage)}**  
+
+Unique Certificate Identifier  
+*Eindeutige Kennung des Zertifikats*  
+**${uvci(c)}**  
+
+[kopiere die Kennung](iohandledlink://copy:${uvci(c)})
+<br/><br/><br/><br/><br/>
+`;

--- a/GetCertificate/printer.ts
+++ b/GetCertificate/printer.ts
@@ -56,43 +56,34 @@ interface IPrintersForLanguage {
   readonly infoRecoveryPrinter: (c: Certificates) => string;
 }
 
-const printersConfigurations = new Map<PreferredLanguage, IPrintersForLanguage>(
-  [
-    [
-      PreferredLanguageEnum.it_IT,
-      {
-        detailVaccinePrinter: vacDetailsIt.getDetailPrinter,
-        detailTestPrinter: testDetailsIt.getDetailPrinter,
-        detailRecoveryPrinter: recoveryDetailsIt.getDetailPrinter,
-        infoVaccinePrinter: vacInfoMultilanguage.getInfoPrinter,
-        infoTestPrinter: vacInfoMultilanguage.getInfoPrinter,
-        infoRecoveryPrinter: vacInfoMultilanguage.getInfoPrinter
-      }
-    ],
-    [
-      PreferredLanguageEnum.en_GB,
-      {
-        detailVaccinePrinter: vacDetailsEn.getDetailPrinter,
-        detailTestPrinter: testDetailsEn.getDetailPrinter,
-        detailRecoveryPrinter: recoveryDetailsEn.getDetailPrinter,
-        infoVaccinePrinter: vacInfoMultilanguage.getInfoPrinter,
-        infoTestPrinter: vacInfoMultilanguage.getInfoPrinter,
-        infoRecoveryPrinter: vacInfoMultilanguage.getInfoPrinter
-      }
-    ],
-    [
-      PreferredLanguageEnum.de_DE,
-      {
-        detailVaccinePrinter: vacDetailsDe.getDetailPrinter,
-        detailTestPrinter: testDetailsDe.getDetailPrinter,
-        detailRecoveryPrinter: recoveryDetailsDe.getDetailPrinter,
-        infoVaccinePrinter: vacInfoMultilanguage.getInfoPrinter,
-        infoTestPrinter: vacInfoMultilanguage.getInfoPrinter,
-        infoRecoveryPrinter: vacInfoMultilanguage.getInfoPrinter
-      }
-    ]
-  ]
-);
+const printersConfigurations: {
+  [key in SupportedLanguage]: IPrintersForLanguage;
+} = {
+  [PreferredLanguageEnum.it_IT]: {
+    detailVaccinePrinter: vacDetailsIt.getDetailPrinter,
+    detailTestPrinter: testDetailsIt.getDetailPrinter,
+    detailRecoveryPrinter: recoveryDetailsIt.getDetailPrinter,
+    infoVaccinePrinter: vacInfoMultilanguage.getInfoPrinter,
+    infoTestPrinter: vacInfoMultilanguage.getInfoPrinter,
+    infoRecoveryPrinter: vacInfoMultilanguage.getInfoPrinter
+  },
+  [PreferredLanguageEnum.en_GB]: {
+    detailVaccinePrinter: vacDetailsEn.getDetailPrinter,
+    detailTestPrinter: testDetailsEn.getDetailPrinter,
+    detailRecoveryPrinter: recoveryDetailsEn.getDetailPrinter,
+    infoVaccinePrinter: vacInfoMultilanguage.getInfoPrinter,
+    infoTestPrinter: vacInfoMultilanguage.getInfoPrinter,
+    infoRecoveryPrinter: vacInfoMultilanguage.getInfoPrinter
+  },
+  [PreferredLanguageEnum.de_DE]: {
+    detailVaccinePrinter: vacDetailsDe.getDetailPrinter,
+    detailTestPrinter: testDetailsDe.getDetailPrinter,
+    detailRecoveryPrinter: recoveryDetailsDe.getDetailPrinter,
+    infoVaccinePrinter: vacInfoMultilanguage.getInfoPrinter,
+    infoTestPrinter: vacInfoMultilanguage.getInfoPrinter,
+    infoRecoveryPrinter: vacInfoMultilanguage.getInfoPrinter
+  }
+};
 
 export const defaultPrinter: IPrintersForLanguage = {
   detailVaccinePrinter: vacDetailsEn.getDetailPrinter,
@@ -114,7 +105,14 @@ export const getPrinterForLanguage = (
   lang: o.Option<PreferredLanguage>
 ): IPrintersForLanguage =>
   lang
-    .chain(l => o.fromNullable(printersConfigurations.get(l)))
+    .chain(l =>
+      o.fromNullable(
+        (printersConfigurations as Record<
+          PreferredLanguage,
+          IPrintersForLanguage
+        >)[l]
+      )
+    )
     .getOrElse(defaultPrinter);
 
 /**

--- a/GetCertificate/valuesets/labTestTypes.ts
+++ b/GetCertificate/valuesets/labTestTypes.ts
@@ -8,20 +8,25 @@ export const labTestTypes: IReadonlyTranslatableMap = {
   placeholder: {
     displays: {
       [PreferredLanguageEnum.it_IT]: VALUESET_PLACEHOLDER,
-      [PreferredLanguageEnum.en_GB]: VALUESET_PLACEHOLDER
+      [PreferredLanguageEnum.en_GB]: VALUESET_PLACEHOLDER,
+      [PreferredLanguageEnum.de_DE]: VALUESET_PLACEHOLDER
     }
   },
   "LP6464-4": {
     displays: {
       [PreferredLanguageEnum.it_IT]: "Test molecolare",
       [PreferredLanguageEnum.en_GB]:
-        "Nucleic acid amplification with probe detection"
+        "Nucleic acid amplification with probe detection",
+      //TODO: Add de_DE translation
+      [PreferredLanguageEnum.de_DE]: ""
     }
   },
   "LP217198-3": {
     displays: {
       [PreferredLanguageEnum.it_IT]: "Test antigenico rapido",
-      [PreferredLanguageEnum.en_GB]: "Rapid immunoassay"
+      [PreferredLanguageEnum.en_GB]: "Rapid immunoassay",
+      //TODO: Add de_DE translation
+      [PreferredLanguageEnum.de_DE]: ""
     }
   }
 };

--- a/GetCertificate/valuesets/testResults.ts
+++ b/GetCertificate/valuesets/testResults.ts
@@ -8,19 +8,24 @@ export const testResults: IReadonlyTranslatableMap = {
   placeholder: {
     displays: {
       [PreferredLanguageEnum.it_IT]: VALUESET_PLACEHOLDER,
-      [PreferredLanguageEnum.en_GB]: VALUESET_PLACEHOLDER
+      [PreferredLanguageEnum.en_GB]: VALUESET_PLACEHOLDER,
+      [PreferredLanguageEnum.de_DE]: VALUESET_PLACEHOLDER
     }
   },
   "260415000": {
     displays: {
       [PreferredLanguageEnum.it_IT]: "Negativo",
-      [PreferredLanguageEnum.en_GB]: "Not detected"
+      [PreferredLanguageEnum.en_GB]: "Not detected",
+      //TODO: Add de_DE translation
+      [PreferredLanguageEnum.de_DE]: ""
     }
   },
   "260373001": {
     displays: {
       [PreferredLanguageEnum.it_IT]: "Positivo",
-      [PreferredLanguageEnum.en_GB]: "Detected"
+      [PreferredLanguageEnum.en_GB]: "Detected",
+      //TODO: Add de_DE translation
+      [PreferredLanguageEnum.de_DE]: ""
     }
   }
 };

--- a/utils/__tests__/conversions.test.ts
+++ b/utils/__tests__/conversions.test.ts
@@ -14,13 +14,15 @@ const translatableMap: IReadonlyTranslatableMap = {
   placeholder: {
     displays: {
       [PreferredLanguageEnum.it_IT]: "---",
-      [PreferredLanguageEnum.en_GB]: "---"
+      [PreferredLanguageEnum.en_GB]: "---",
+      [PreferredLanguageEnum.de_DE]: "---"
     }
   },
   "0001": {
     displays: {
       [PreferredLanguageEnum.it_IT]: "test display in it",
-      [PreferredLanguageEnum.en_GB]: "test display in en"
+      [PreferredLanguageEnum.en_GB]: "test display in en",
+      [PreferredLanguageEnum.de_DE]: "test display in de"
     }
   }
 };

--- a/utils/conversions.ts
+++ b/utils/conversions.ts
@@ -26,12 +26,13 @@ export const errorsToError = (errors: Errors): Error =>
  * An object representing a value translated in every supported languages
  */
 
-export type SuportedLanguage =
+export type SupportedLanguage =
   | PreferredLanguageEnum.en_GB
+  | PreferredLanguageEnum.de_DE
   | PreferredLanguageEnum.it_IT;
 
 export interface ITranslatable {
-  readonly displays: { [key in SuportedLanguage]: string };
+  readonly displays: { [key in SupportedLanguage]: string };
 }
 
 export interface IReadonlyTranslatableMap {


### PR DESCRIPTION
#### List of Changes
This PR adds the Three Eu Covid Cert templates (vaccination, test and recovery) in German Language plus the "info" templates. 
Some minor fixes has been applied to the Italian template too.

#### Motivation and Context
The certificate must be available als in german language due to protection of linguistic minorities compliance

#### How Has This Been Tested?
Not tested at all 😓 Actually no test can be runned until the German Language is supported by both backend and fronted

#### Screenshots (if appropriate):
N/A

#### Types of changes
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
