### PR TITLE
details vaccination templates updated with the new duration

### DIFF
--- a/GetCertificate/__tests__/__snapshots__/printer_recovery_info_de.test.ts.snap
+++ b/GetCertificate/__tests__/__snapshots__/printer_recovery_info_de.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Printer - Recovery - Info - de_DE should print its markdown 1`] = `
 "
 Surname(s) and forename(s)  
-*Vorname und Nachname*  
+*Nachname und Vorname*  
 **Di Caprio Marilù Teresa**  
 
 Date of birth  

--- a/GetCertificate/__tests__/__snapshots__/printer_test_info_de.test.ts.snap
+++ b/GetCertificate/__tests__/__snapshots__/printer_test_info_de.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Printer - Test - Info - de_DE should print its markdown 1`] = `
 "
 Surname(s) and forename(s)  
-*Vorname und Nachname*  
+*Nachname und Vorname*  
 **Di Caprio Marilù Teresa**  
 
 Date of birth  

--- a/GetCertificate/__tests__/__snapshots__/printer_vaccine_detail_de.test.ts.snap
+++ b/GetCertificate/__tests__/__snapshots__/printer_vaccine_detail_de.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Printer - Test - Detail - de_DE should print its markdown 1`] = `
 "
 ## Impfstoffdaten  
 ***
-**Zertifizierung gültig für 270 Tage (9 Monate) ab dem Datum der letzten Verabreichung**
+**Zertifizierung gültig für 12 Monate ab dem Datum der letzten Verabreichung**
 ***
 
 Zielkrankheit oder -wirkstoff  

--- a/GetCertificate/__tests__/__snapshots__/printer_vaccine_detail_en.test.ts.snap
+++ b/GetCertificate/__tests__/__snapshots__/printer_vaccine_detail_en.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Printer - Test - Detail - en_GB should print its markdown 1`] = `
 "
 ## Vaccination Certificate  
 ***
-**Certification valid for 270 days (9 months) from the date of the last administration**
+**Certification valid for 12 months from the date of the last administration**
 ***
 
 Disease or agent targeted  

--- a/GetCertificate/__tests__/__snapshots__/printer_vaccine_detail_it.test.ts.snap
+++ b/GetCertificate/__tests__/__snapshots__/printer_vaccine_detail_it.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Printer - Test - Detail - it_IT should print its markdown 1`] = `
 "
 ## Dati Vaccino  
 ***
-**Certificazione valida 270 giorni (9 mesi) dalla data dell'ultima somministrazione**
+**Certificazione valida 12 mesi dalla data dell'ultima somministrazione**
 ***
 
 Malattia o agente bersaglio  

--- a/GetCertificate/__tests__/__snapshots__/printer_vaccine_info_de.test.ts.snap
+++ b/GetCertificate/__tests__/__snapshots__/printer_vaccine_info_de.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Printer - Vaccine - Info - de_DE should print its markdown 1`] = `
 "
 Surname(s) and forename(s)  
-*Vorname und Nachname*  
+*Nachname und Vorname*  
 **Di Caprio Marilù Teresa**  
 
 Date of birth  

--- a/GetCertificate/markdown/eucovidcertDetailsVaccinationDe.ts
+++ b/GetCertificate/markdown/eucovidcertDetailsVaccinationDe.ts
@@ -12,11 +12,10 @@ export const getDetailPrinter = (v: VaccinationEntry): string =>
   `
 ## Impfstoffdaten  
 ***
-${
-  isVaccinationProcessEnded(v)
-    ? "**Zertifizierung gültig für 270 Tage (9 Monate) ab dem Datum der letzten Verabreichung**"
+${isVaccinationProcessEnded(v)
+    ? "**Zertifizierung gültig für 12 Monate ab dem Datum der letzten Verabreichung**"
     : "**Zertifizierung gültig bis zur nächsten Dosis**"
-}
+  }
 ***
 
 Zielkrankheit oder -wirkstoff  

--- a/GetCertificate/markdown/eucovidcertDetailsVaccinationDe.ts
+++ b/GetCertificate/markdown/eucovidcertDetailsVaccinationDe.ts
@@ -12,10 +12,11 @@ export const getDetailPrinter = (v: VaccinationEntry): string =>
   `
 ## Impfstoffdaten  
 ***
-${isVaccinationProcessEnded(v)
+${
+  isVaccinationProcessEnded(v)
     ? "**Zertifizierung gültig für 12 Monate ab dem Datum der letzten Verabreichung**"
     : "**Zertifizierung gültig bis zur nächsten Dosis**"
-  }
+}
 ***
 
 Zielkrankheit oder -wirkstoff  

--- a/GetCertificate/markdown/eucovidcertDetailsVaccinationEn.ts
+++ b/GetCertificate/markdown/eucovidcertDetailsVaccinationEn.ts
@@ -12,10 +12,11 @@ export const getDetailPrinter = (v: VaccinationEntry): string =>
   `
 ## Vaccination Certificate  
 ***
-${isVaccinationProcessEnded(v)
+${
+  isVaccinationProcessEnded(v)
     ? "**Certification valid for 12 months from the date of the last administration**"
     : "**Certification valid until next dose**"
-  }
+}
 ***
 
 Disease or agent targeted  

--- a/GetCertificate/markdown/eucovidcertDetailsVaccinationEn.ts
+++ b/GetCertificate/markdown/eucovidcertDetailsVaccinationEn.ts
@@ -12,11 +12,10 @@ export const getDetailPrinter = (v: VaccinationEntry): string =>
   `
 ## Vaccination Certificate  
 ***
-${
-  isVaccinationProcessEnded(v)
-    ? "**Certification valid for 270 days (9 months) from the date of the last administration**"
+${isVaccinationProcessEnded(v)
+    ? "**Certification valid for 12 months from the date of the last administration**"
     : "**Certification valid until next dose**"
-}
+  }
 ***
 
 Disease or agent targeted  

--- a/GetCertificate/markdown/eucovidcertDetailsVaccinationIt.ts
+++ b/GetCertificate/markdown/eucovidcertDetailsVaccinationIt.ts
@@ -12,10 +12,11 @@ export const getDetailPrinter = (v: VaccinationEntry): string =>
   `
 ## Dati Vaccino  
 ***
-${isVaccinationProcessEnded(v)
+${
+  isVaccinationProcessEnded(v)
     ? "**Certificazione valida 12 mesi dalla data dell'ultima somministrazione**"
     : "**Certificazione valida fino alla prossima dose**"
-  }
+}
 ***
 
 Malattia o agente bersaglio  

--- a/GetCertificate/markdown/eucovidcertDetailsVaccinationIt.ts
+++ b/GetCertificate/markdown/eucovidcertDetailsVaccinationIt.ts
@@ -12,11 +12,10 @@ export const getDetailPrinter = (v: VaccinationEntry): string =>
   `
 ## Dati Vaccino  
 ***
-${
-  isVaccinationProcessEnded(v)
-    ? "**Certificazione valida 270 giorni (9 mesi) dalla data dell'ultima somministrazione**"
+${isVaccinationProcessEnded(v)
+    ? "**Certificazione valida 12 mesi dalla data dell'ultima somministrazione**"
     : "**Certificazione valida fino alla prossima dose**"
-}
+  }
 ***
 
 Malattia o agente bersaglio  

--- a/GetCertificate/markdown/samples/OK_eucovidcert_details_vaccination_en.md
+++ b/GetCertificate/markdown/samples/OK_eucovidcert_details_vaccination_en.md
@@ -1,7 +1,7 @@
 ## Vaccination Certificate
 ***
 <!-- if dn==sd -->
-**Certification valid for 270 days (9 months) from the date of the last administration**
+**Certification valid for 12 months from the date of the last administration**
 <!-- else if dn<sd -->
 **Certification valid until next dose**
 <!-- endif -->

--- a/GetCertificate/markdown/samples/OK_eucovidcert_details_vaccination_it.md
+++ b/GetCertificate/markdown/samples/OK_eucovidcert_details_vaccination_it.md
@@ -1,7 +1,7 @@
 ## Dati Vaccino
 ***
 <!-- if dn==sd -->
-**Certificazione valida 270 giorni (9 mesi) dalla data dell'ultima somministrazione**
+**Certificazione valida 12 mesi dalla data dell'ultima somministrazione**
 <!-- else if dn<sd -->
 **Certificazione valida fino alla prossima dose**
 <!-- endif -->


### PR DESCRIPTION
Updated vaccination details template due to the convertion of the DL 105, that extends the validity of che vaccination certificates to 12 month.

#### List of Changes
3 strings in the vaccination details templates

#### Motivation and Context
The Italian Government has modified the duration of the vaccination certificate

#### How Has This Been Tested?
No test performed

#### Screenshots (if appropriate):
no needed

#### Types of changes
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


