### PR TITLE
[#IC-101]  Add 404 support to get certificate

### DIFF
--- a/GetCertificate/__tests__/handler.test.ts
+++ b/GetCertificate/__tests__/handler.test.ts
@@ -137,7 +137,7 @@ describe("GetCertificate", () => {
     }
   });
 
-  it("GIVEN an expired certificate request WHEN the getCertificate is invoked THEN the getCertificte return an expired certificate", async () => {
+  it("GIVEN an expired certificate request WHEN the getCertificate is invoked THEN the getCertificate return an expired certificate", async () => {
     const aDGCReturnValue = { status: 404 };
 
     const client = {

--- a/GetCertificate/__tests__/handler.test.ts
+++ b/GetCertificate/__tests__/handler.test.ts
@@ -157,7 +157,7 @@ describe("GetCertificate", () => {
 
       expect(val).toMatchObject({
         kind: "IResponseSuccessJson",
-        value: { info: "‎", status: "expired" }
+        value: { info: " ", status: "expired" }
       });
     } catch (error) {
       fail(error);

--- a/GetCertificate/__tests__/handler.test.ts
+++ b/GetCertificate/__tests__/handler.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../../__mocks__/clientSelectorConfig";
 import { fakeQRCodeInfo } from "../../utils/fakeDGCClient";
 import { StatusEnum } from "../../generated/definitions/ValidCertificate";
+import { ResponseSuccessJson } from "@pagopa/ts-commons/lib/responses";
 
 const aFiscalCode = "PRVPRV25A01H501B";
 
@@ -131,6 +132,33 @@ describe("GetCertificate", () => {
           expect(val.value.detail!.length).toBeGreaterThan(0);
         }
       }
+    } catch (error) {
+      fail(error);
+    }
+  });
+
+  it("GIVEN an expired certificate request WHEN the getCertificate is invoked THEN the getCertificte return an expired certificate", async () => {
+    const aDGCReturnValue = { status: 404 };
+
+    const client = {
+      getCertificateByAutAndCF: (_: any) =>
+        Promise.resolve(e.right(aDGCReturnValue))
+    };
+
+    const mockClientSelector: ReturnType<typeof createDGCClientSelector> = {
+      select: (hashedFiscalCode): DGCClient => (client as any) as DGCClient
+    };
+
+    try {
+      const val = await GetCertificateHandler(mockClientSelector)(context, {
+        fiscal_code: aFiscalCode as FiscalCode,
+        auth_code: "anAuthCode"
+      });
+
+      expect(val).toMatchObject({
+        kind: "IResponseSuccessJson",
+        value: { info: "‎", status: "expired" }
+      });
     } catch (error) {
       fail(error);
     }

--- a/GetCertificate/handler.ts
+++ b/GetCertificate/handler.ts
@@ -109,7 +109,7 @@ export const GetCertificateHandler = (
             e,
             TE.fromPredicate(
               i => i.status === 200,
-              () => ({ info: "‎", status: ExpiredEnum.expired })
+              () => ({ info: " ", status: ExpiredEnum.expired })
             ),
             TE.map(i => i.value),
             // try to enhance raw certificate with parsed data

--- a/openapi/dgc.yaml
+++ b/openapi/dgc.yaml
@@ -30,6 +30,10 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/SearchSingleQrCodeResponseDTO'
+        '404':
+          description: Not Found
+          schema:
+            $ref: '#/definitions/SearchSingleQrCodeResponseDTO'
         '500':
           description: Internal Server Error
           schema:


### PR DESCRIPTION
The DGC service "getCertificateByAutAndCF" will not allow you to retrieve exprired certificate (retrun a 404 - Not Found).
This function will map the 404 error with the ExpiredCertificate already defined in the openapi.
With this change, the APP will manage the expired certificate without releasing a new version.

#### List of Changes
Add 404 in the DGC opeanpi.
Add mapping between 404 and ExpiredCertificate in the getCertificate handler.

#### Motivation and Context
Opening an EU Covid Certificate message in APP could throw an error.

#### How Has This Been Tested?
unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
