### PR TITLE
[#IC-218] Send `revoked` status instead of `expired`

### DIFF
--- a/GetCertificate/__tests__/handler.test.ts
+++ b/GetCertificate/__tests__/handler.test.ts
@@ -153,7 +153,7 @@ describe("GetCertificate", () => {
     ${"no language"}             | ${[]}
     ${"no language (undefined)"} | ${undefined}
   `(
-    "GIVEN an expired certificate request with $scenario WHEN the getCertificate is invoked THEN the getCertificate return an expired certificate",
+    "GIVEN an expired/revoked certificate request with $scenario WHEN the getCertificate is invoked THEN the getCertificate return a revoked certificate",
     async ({ preferred_languages }) => {
       const aDGCReturnValue = { status: 404 };
 
@@ -177,7 +177,7 @@ describe("GetCertificate", () => {
           kind: "IResponseSuccessJson",
           value: {
             info: expect.stringMatching("^.*[a-zA-Z]+.*$"), // at least one character
-            status: "expired",
+            status: "revoked",
             header_info: expect.objectContaining({
               logo_id: "",
               title: "",

--- a/GetCertificate/__tests__/handler.test.ts
+++ b/GetCertificate/__tests__/handler.test.ts
@@ -16,7 +16,7 @@ import {
 import { fakeQRCodeInfo } from "../../utils/fakeDGCClient";
 import { StatusEnum } from "../../generated/definitions/ValidCertificate";
 import { PreferredLanguageEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/PreferredLanguage";
-import { string } from "fp-ts";
+import { RevokedCertificate } from "../../generated/definitions/RevokedCertificate";
 
 const aFiscalCode = "PRVPRV25A01H501B";
 
@@ -185,6 +185,7 @@ describe("GetCertificate", () => {
             })
           }
         });
+        expect(RevokedCertificate.is((val as any).value)).toBe(true);
       } catch (error) {
         fail(error);
       }

--- a/GetCertificate/handler.ts
+++ b/GetCertificate/handler.ts
@@ -35,12 +35,12 @@ import { Mime_typeEnum } from "../generated/definitions/QRCode";
 import { toSHA256 } from "../utils/conversions";
 import { createDGCClientSelector } from "../utils/dgcClientSelector";
 import { toString } from "../utils/conversions";
-import { StatusEnum as ExpiredEnum } from "../generated/definitions/ExpiredCertificate";
+import { StatusEnum as RevokedEnum } from "../generated/definitions/RevokedCertificate";
 import { SearchSingleQrCodeResponseDTO } from "../generated/dgc/SearchSingleQrCodeResponseDTO";
 import { parseQRCode } from "./parser";
 import {
   printDetails,
-  printExpiredInfo,
+  printExpiredOrRevokedInfo,
   printInfo,
   printUvci
 } from "./printer";
@@ -82,8 +82,10 @@ export const processSuccessCertificateGeneration = (
       i => i.status === 200,
       () => ({
         header_info: getFallbackHeaderInfoForLanguage(selectedLanguage),
-        info: printExpiredInfo(selectedLanguage) || EMPTY_STRING_FOR_MARKDOWN,
-        status: ExpiredEnum.expired
+        info:
+          printExpiredOrRevokedInfo(selectedLanguage) ||
+          EMPTY_STRING_FOR_MARKDOWN,
+        status: RevokedEnum.revoked
       })
     ),
     TE.map(i => i.value),

--- a/GetCertificate/markdown/eucovidcertExpiredInfoEn.ts
+++ b/GetCertificate/markdown/eucovidcertExpiredInfoEn.ts
@@ -3,4 +3,4 @@
  */
 
 export const getInfoPrinter = (): string =>
-  `Your certificate in invalid: it may have expired or been temporarily revoked.`;
+  `Your certificate is invalid: it may have expired or been temporarily revoked.`;

--- a/GetCertificate/printer.ts
+++ b/GetCertificate/printer.ts
@@ -182,8 +182,9 @@ export const printUvci = (
  * @param lang the preferred language
  * @returns a string containing the Info markdown
  */
-export const printExpiredInfo = (lang: o.Option<PreferredLanguage>): string =>
-  getPrinterForLanguage(lang).expiredInfoPrinter();
+export const printExpiredOrRevokedInfo = (
+  lang: o.Option<PreferredLanguage>
+): string => getPrinterForLanguage(lang).expiredInfoPrinter();
 
 /**
  * Check if Vaccination has ended


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- return `revoked` instead of `expired` status when DGC return 404.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We will treat every 404 as revoked, which is an hard statement. 
That includes tests certificates which normally expire after 48hrs.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
